### PR TITLE
PHP image version updated to 8.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,22 @@
-FROM php:7.4-fpm
+FROM php:8.1-fpm
 
 # Устанавливаем зависимости
 RUN apt-get update && apt-get install -y libzip-dev libgmp-dev \
     libicu-dev zlib1g-dev libpng-dev libjpeg-dev libxml2-dev \
-    libfreetype6-dev libmcrypt-dev libcurl3-dev libonig-dev \
-    libwebp-dev libjpeg62-turbo-dev libxpm-dev
+    libfreetype6-dev libonig-dev libwebp-dev libjpeg62-turbo-dev \
+    libxpm-dev libcurl4-openssl-dev pkg-config
 
 # Устанавливаем расширения PHP
-RUN docker-php-ext-install -j$(nproc) mysqli pdo pdo_mysql mbstring json ctype curl
+RUN docker-php-ext-install -j$(nproc) mysqli pdo pdo_mysql mbstring ctype curl
 RUN docker-php-ext-install zip
 RUN docker-php-ext-install gmp
-RUN pecl install mcrypt-1.0.7
-RUN docker-php-ext-enable mcrypt
 RUN docker-php-ext-configure gd --with-jpeg --with-webp --with-freetype
 RUN docker-php-ext-install -j$(nproc) gd
 RUN docker-php-ext-install -j$(nproc) intl bcmath
 RUN apt-get clean
+
+# Hide PHP version
+RUN echo "expose_php = Off" > /usr/local/etc/php/conf.d/security.ini
 
 # Устанавливаем рабочий каталог
 WORKDIR /var/www/html/
@@ -27,4 +28,4 @@ COPY --from=composer /usr/bin/composer /usr/bin/composer
 COPY . .
 
 RUN chmod -R 775 /var/www/html/storage
-CMD bash -c "composer install && php-fpm"
+CMD bash -c "composer install --ignore-platform-reqs && php-fpm"


### PR DESCRIPTION
You should upgrade to this version for security reasons. I highly recommend backing up everything before upgrading.
Use `docker compose up -d --build` command to update.